### PR TITLE
Move cached_result to a blob field for better performance

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,12 @@ Changelog
 
 5.2.dev0 - (unreleased)
 -----------------------
+* Feature: moved cached_result sparql cache to a blob field in order to
+  decrease object size, especially useful in versioning and history diff
+  [ichimdav refs #17334]
+* Upgrade step: Within "Plone > Site setup > Add-ons" click on
+  upgrade button available for eea.sparql with www8 service instance
+  [ichimdav refs #17334]
 
 5.1 - (2016-01-19)
 ------------------

--- a/eea/sparql/browser/js/datasource.js
+++ b/eea/sparql/browser/js/datasource.js
@@ -36,6 +36,9 @@ $(document).ready(function() {
 
 });
 
-Browser.onUploadComplete = function() {
-    // don't reload the page after uploading file
-};
+if (window.Browser) {
+    window.Browser.onUploadComplete = function(){
+        // don't reload the page after uploading file
+    };
+}
+

--- a/eea/sparql/cache/__init__.py
+++ b/eea/sparql/cache/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
     from eea.sparql.cache.nocache import ramcache
     from eea.sparql.cache.nocache import flush, flushBackRefs, flushRelatedItems
 
-from eea.sparql.cache.cache import cacheSparqlKey
+from eea.sparql.cache.cache import cacheSparqlKey, cacheSparqlMethodKey
 
 __all__ = [
     ramcache.__name__,

--- a/eea/sparql/cache/__init__.py
+++ b/eea/sparql/cache/__init__.py
@@ -19,6 +19,7 @@ from eea.sparql.cache.cache import cacheSparqlKey, cacheSparqlMethodKey
 __all__ = [
     ramcache.__name__,
     cacheSparqlKey.__name__,
+    cacheSparqlMethodKey.__name__,
     flush.__name__,
     flushBackRefs.__name__,
     flushRelatedItems.__name__,

--- a/eea/sparql/cache/cache.py
+++ b/eea/sparql/cache/cache.py
@@ -4,3 +4,9 @@ def cacheSparqlKey(method, self, *args, **kwargs):
     """ Generate unique cache id
     """
     return self.absolute_url(1)
+
+
+def cacheSparqlMethodKey(method, self):
+    """ Generate unique cache id
+    """
+    return self.absolute_url(1) + '/' + method.__name__

--- a/eea/sparql/content/__init__.py
+++ b/eea/sparql/content/__init__.py
@@ -1,2 +1,6 @@
 """ Content init module
 """
+
+from Products.validation.config import validation
+from eea.sparql.content.validators import SparqlQueryValidator
+validation.register(SparqlQueryValidator('isSparqlOverLimit'))

--- a/eea/sparql/content/sparql.py
+++ b/eea/sparql/content/sparql.py
@@ -309,17 +309,12 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
             self.setSparqlCacheResults(new_result)
             new_sparql_results = []
             rows = new_result.get('result', {}).get('rows', {})
-            # if len(rows) < 201:
             for row in rows:
                 for val in row:
                     new_sparql_results.append(unicode(val) + " | ")
             new_sparql_results[-1] = new_sparql_results[-1][0:-3]
             new_sparql_results = "".join(new_sparql_results) + "\n"
             self.setSparql_results(new_sparql_results)
-            # else:
-            #    self.setSparql_results(
-            #        "Too many rows (%s), comparation is disabled"
-            #        % len(rows))
             comment = "query has run - result changed"
         if self.portal_type in pr.getVersionableContentTypes():
             comment = comment.encode('utf')
@@ -334,6 +329,10 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
                     """Changes Saved. Versioning for this file
                        has been disabled because it is too large.""",
                     msgtype="warn")
+
+        if new_result.get('exception', None):
+            cached_result['exception'] = new_result['exception']
+            self.setSparqlCacheResults(cached_result)
 
     security.declareProtected(view, 'execute')
     def execute(self, **arg_values):

--- a/eea/sparql/content/sparql.py
+++ b/eea/sparql/content/sparql.py
@@ -110,7 +110,8 @@ SparqlBaseSchema = atapi.Schema((
             helper_css=("sparql_textfield_with_preview.css",),
             label="Query",
         ),
-        required=1
+        required=1,
+        validators=('isSparqlOverLimit',)
     ),
     BooleanField(
         name='sparql_static',
@@ -233,7 +234,11 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
         if getattr(self, 'sparql_results_are_cached', None):
             return self._getCachedSparqlResults()
         field = self.getSparql_results_cached()
-        return cPickle.loads(field.data) if field and field.data else {}
+        empty_result = {"result": {"rows": "", "var_names": "",
+                                   "has_result": ""}}
+        return cPickle.loads(field.data) if field and field.data else \
+            empty_result
+
 
     security.declareProtected(view, 'setSparqlCacheResults')
     def setSparqlCacheResults(self, result):

--- a/eea/sparql/content/sparql.py
+++ b/eea/sparql/content/sparql.py
@@ -224,6 +224,7 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
         """
         return cPickle.loads(self.getSparql_results_cached().data)
 
+    security.declarePublic("getSparqlCacheResults")
     def getSparqlCacheResults(self):
         """
         :return: Sparql results
@@ -234,14 +235,14 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
         field = self.getSparql_results_cached()
         return cPickle.loads(field.data) if field and field.data else {}
 
-    security.declareProtected(view, 'setSparqlCachedResults')
+    security.declareProtected(view, 'setSparqlCacheResults')
     def setSparqlCacheResults(self, result):
         """ Set Sparql Cache results
         """
         self.sparql_results_are_cached = True
         self.setSparql_results_cached(cPickle.dumps(result))
 
-    security.declareProtected(view, 'invalidateSparqlCacheResult')
+    security.declareProtected(view, 'invalidateSparqlCacheResults')
     def invalidateSparqlCacheResults(self):
         """ Invalidate sparql results
         """
@@ -278,7 +279,7 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
     def updateLastWorkingResults(self, **arg_values):
         """ update cached last working results of a query
         """
-        cached_result = self.get_cached_results()
+        cached_result = self.getSparqlCacheResults()
         cooked_query = interpolate_query(self.query, arg_values)
 
         args = (self.endpoint_url, cooked_query)
@@ -338,7 +339,7 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
     def execute(self, **arg_values):
         """ override execute, if possible return the last working results
         """
-        cached_result = self.get_cached_results()
+        cached_result = self.getSparqlCacheResults()
         if len(arg_values) == 0:
             return cached_result
 
@@ -368,7 +369,7 @@ def async_updateLastWorkingResults(obj,
 
         refresh_rate = getattr(obj, "refresh_rate", "Weekly")
         if refresh_rate == 'Once':
-            cached_result = obj.get_cached_results()
+            cached_result = obj.getSparqlCacheResults()
             if len(cached_result.get('result', {}).get('rows', {})) == 0:
                 refresh_rate = 'Hourly'
         else:

--- a/eea/sparql/content/sparql.py
+++ b/eea/sparql/content/sparql.py
@@ -267,15 +267,14 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
                 if len(new_result.get("result", {}).get("rows", {})) > 0:
                     force_save = True
                 else:
-                    if len(cached_result.get('result', {}).\
-                        get('rows', {})) == 0:
+                    if len(cached_result.get('result', {}).get('rows', {})) \
+                            == 0:
                         force_save = True
 
         pr = getToolByName(self, 'portal_repository')
         comment = "query has run - no result changes"
         if force_save:
             self.setSparql_results_cached(cPickle.dumps(new_result))
-            cached_result = new_result
             new_sparql_results = []
             rows = new_result.get('result', {}).get('rows', {})
             # if len(rows) < 201:
@@ -292,7 +291,6 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
             comment = "query has run - result changed"
         if self.portal_type in pr.getVersionableContentTypes():
             comment = comment.encode('utf')
-
             try:
                 oldSecurityManager = getSecurityManager()
                 newSecurityManager(None, SpecialUsers.system)
@@ -304,9 +302,6 @@ class Sparql(base.ATCTContent, ZSPARQLMethod):
                     """Changes Saved. Versioning for this file
                        has been disabled because it is too large.""",
                     msgtype="warn")
-        # TODO add exception data
-        if new_result.get('exception', None):
-            cached_result['exception'] = new_result['exception']
 
 
     # @ramcache(cacheSparqlMethodKey, dependencies=['eea.sparql'])
@@ -352,11 +347,10 @@ def async_updateLastWorkingResults(obj,
         obj.updateLastWorkingResults()
 
         refresh_rate = getattr(obj, "refresh_rate", "Weekly")
-        cached_result = obj.get_cached_results()
-        if (len(cached_result.get('result', {}).get('rows',
-                                                                {})) == 0) and \
-                (refresh_rate == 'Once'):
-            refresh_rate = 'Hourly'
+        if refresh_rate == 'Once':
+            cached_result = obj.get_cached_results()
+            if len(cached_result.get('result', {}).get('rows', {})) == 0:
+                refresh_rate = 'Hourly'
         else:
             if bookmarks_folder_added:
                 notify(SparqlBookmarksFolderAdded(obj))
@@ -364,13 +358,10 @@ def async_updateLastWorkingResults(obj,
 
         before = datetime.datetime.now(pytz.UTC)
 
-#        delay = before + datetime.timedelta(seconds=10)
         delay = before + datetime.timedelta(hours=1)
         if refresh_rate == "Daily":
             delay = before + datetime.timedelta(days=1)
-#            delay = before + datetime.timedelta(seconds=60)
         if refresh_rate == "Weekly":
-#            delay = before + datetime.timedelta(seconds=120)
             delay = before + datetime.timedelta(weeks=1)
         if refresh_rate != "Once":
             async = getUtility(IAsyncService)

--- a/eea/sparql/content/validators.py
+++ b/eea/sparql/content/validators.py
@@ -1,0 +1,61 @@
+""" Custom AT Validators
+"""
+from Products.statusmessages.interfaces import IStatusMessage
+from Products.validation.interfaces.IValidator import IValidator
+from zope.annotation import IAnnotations
+from zope.interface import implements
+
+from Products.ZSPARQLMethod.Method import run_with_timeout
+from Products.ZSPARQLMethod.Method import query_and_get_result
+
+
+
+class SparqlQueryValidator(object):
+    """ Validator
+    """
+    implements(IValidator)
+
+    def __init__(self, name, title='Sparql Query result size',
+                 description='Check if sparql_query result is too big'):
+        self.name = name
+        self.title = title or name
+        self.description = description
+
+    def run_query(self, request, func, spec):
+        """
+        :param request:
+        :type request:
+        :param func:
+        :type func:
+        :param spec:
+        :type spec:
+        :return:
+        :rtype:
+        """
+        cache = IAnnotations(request)
+        key = 'query_result'
+        data = cache.get('query_result', None)
+        if data is not None:
+            data = run_with_timeout(15, func, *spec)
+            cache[key] = data
+        return data
+
+    def __call__(self, value, *args, **kwargs):
+        """ Check if provided query is within size limit """
+        obj = kwargs.get('instance')
+        request = kwargs['REQUEST']
+        if 'atct_edit' not in request.URL0:
+            return 1
+
+        arg_spec = (obj.endpoint_url, value)
+
+        results = self.run_query(request, query_and_get_result, arg_spec)
+        results_len = len(results.get('result', {}).get('rows', {}))
+        if results_len > 9000:
+            msg = "The query result is too large given that there " \
+                  "are %s rows" % results_len
+            IStatusMessage(request).addStatusMessage(str(msg),
+                                                     type='warning')
+            return 1
+        return 1
+

--- a/eea/sparql/content/validators.py
+++ b/eea/sparql/content/validators.py
@@ -9,7 +9,6 @@ from Products.ZSPARQLMethod.Method import run_with_timeout
 from Products.ZSPARQLMethod.Method import query_and_get_result
 
 
-
 class SparqlQueryValidator(object):
     """ Validator
     """
@@ -35,7 +34,7 @@ class SparqlQueryValidator(object):
         cache = IAnnotations(request)
         key = 'query_result'
         data = cache.get('query_result', None)
-        if data is not None:
+        if data is None:
             data = run_with_timeout(15, func, *spec)
             cache[key] = data
         return data

--- a/eea/sparql/content/validators.py
+++ b/eea/sparql/content/validators.py
@@ -22,14 +22,14 @@ class SparqlQueryValidator(object):
 
     def run_query(self, request, func, spec):
         """
-        :param request:
-        :type request:
-        :param func:
-        :type func:
-        :param spec:
-        :type spec:
-        :return:
-        :rtype:
+        :param request: Object request
+        :type request: object
+        :param func: query_and_get_result funcion used to query Sparql
+        :type func: function
+        :param spec: Endpoint url and sparql query
+        :type spec: tuple
+        :return: Dict with Sparql results
+        :rtype: dict
         """
         cache = IAnnotations(request)
         key = 'query_result'
@@ -47,12 +47,14 @@ class SparqlQueryValidator(object):
             return 1
 
         arg_spec = (obj.endpoint_url, value)
-
         results = self.run_query(request, query_and_get_result, arg_spec)
         results_len = len(results.get('result', {}).get('rows', {}))
-        if results_len > 9000:
-            msg = "The query result is too large given that there " \
-                  "are %s rows" % results_len
+        pprop = obj.portal_properties
+        site_props = getattr(pprop, 'site_properties', None)
+        max_rows = site_props.getProperty('sparql_max_row_length', 9000)
+        sparql_msg = site_props.getProperty('sparql_max_row_msg', "%s %s")
+        msg = sparql_msg % (results_len, max_rows)
+        if results_len > max_rows:
             IStatusMessage(request).addStatusMessage(str(msg),
                                                      type='warning')
             return 1

--- a/eea/sparql/profiles/default/metadata.xml
+++ b/eea/sparql/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4500</version>
+  <version>5200</version>
   <dependencies>
     <dependency>profile-eea.versions:default</dependency>
     <dependency>profile-Products.DataGridField:default</dependency>

--- a/eea/sparql/skins/sparql_templates/sparql_textfield_with_preview.js
+++ b/eea/sparql/skins/sparql_templates/sparql_textfield_with_preview.js
@@ -75,7 +75,7 @@ function check_relations() {
             var back_rels = JSON.parse(data);
             if (back_rels.length !== 0) {
                 var warningMessage = jQuery(
-                    '<dl class="portalMessage">' +
+                    '<dl class="portalMessage warning">' +
                         '<dt>Warning</dt>' +
                         '<div style="clear:both"></div' +
                         '<dd>' +
@@ -95,7 +95,6 @@ function check_relations() {
         }
     });
 
-//    jQuery("<div>XXX</div>").after(".documentFirstHeading");
 }
 jQuery(document).ready(function($) {
     jQuery(".sparql-query-results-preview").click(preview_sparql);

--- a/eea/sparql/upgrades/configure.zcml
+++ b/eea/sparql/upgrades/configure.zcml
@@ -13,6 +13,11 @@
       handler="eea.sparql.upgrades.evolve5200.migrate_sparql_cached_result"
     />
 
+      <genericsetup:upgradeStep
+          title="Add Sparql warning message for too many rows results"
+          handler="eea.sparql.upgrades.evolve5200.add_sparql_max_row_length_properties"
+      />
+
   </genericsetup:upgradeSteps>
 
   <!-- 4.4 => 4.5 -->

--- a/eea/sparql/upgrades/configure.zcml
+++ b/eea/sparql/upgrades/configure.zcml
@@ -2,6 +2,19 @@
   xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
   i18n_domain="eea">
 
+  <!-- 4.5 => 5.2 -->
+  <genericsetup:upgradeSteps
+    source="4500"
+    destination="5200"
+    profile="eea.sparql:default">
+
+    <genericsetup:upgradeStep
+      title="Migrate cached_result to sparql_results_cached blob field"
+      handler="eea.sparql.upgrades.evolve5200.migrate_sparql_cached_result"
+    />
+
+  </genericsetup:upgradeSteps>
+
   <!-- 4.4 => 4.5 -->
   <genericsetup:upgradeSteps
     source="4400"

--- a/eea/sparql/upgrades/evolve5200.py
+++ b/eea/sparql/upgrades/evolve5200.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("eea.sparql.upgrades")
 
 
 def migrate_sparql_cached_result(context):
-    """ Migrate sparqls cached_result to a blob field
+    """ Migrate Sparql's cached_result to a blob field
     """
 
     catalog = getToolByName(context, 'portal_catalog')
@@ -48,3 +48,16 @@ def migrate_sparql_cached_result(context):
     message = 'Migrated cached_result for %s Sparqls ...' % migrated
     logger.info(message)
     return message
+
+
+def add_sparql_max_row_length_properties(context):
+    """ Add site properties sparql max rows length and msg
+    """
+    pprop = getToolByName(context, 'portal_properties')
+    site_properties = pprop.site_properties
+    if not site_properties.hasProperty('sparql_max_row_length'):
+        site_properties._setProperty('sparql_max_row_length', 9000, 'int')
+    if not site_properties.hasProperty('sparql_max_row_msg'):
+        msg = "The SPARQL query returns a large results of %s rows." \
+             " We recommend to limit the query in order to be below %s"
+        site_properties._setProperty('sparql_max_row_msg', msg, 'text')

--- a/eea/sparql/upgrades/evolve5200.py
+++ b/eea/sparql/upgrades/evolve5200.py
@@ -1,0 +1,43 @@
+""" Migrate cached_result attribute for sparql objects
+"""
+
+import logging
+from Products.CMFCore.utils import getToolByName
+import transaction
+
+logger = logging.getLogger("eea.sparql.upgrades")
+
+
+def migrate_sparql_cached_result(context):
+    """ Migrate sparqls cached_result to a blob field
+    """
+
+    catalog = getToolByName(context, 'portal_catalog')
+    brains = catalog.searchResults(portal_type='Sparql', Language='all',
+                                   show_inactive=True)
+
+    log_total = len(brains)
+    log_count = 0
+    migrated = 0
+    for brain in brains:
+        log_count += 1
+        logger.info('PATH %s::%s: %s', log_count, log_total, brain.getPath())
+        try:
+            obj = brain.getObject()
+        except Exception:
+            logger.info('FAILED getObject %s::%s: %s', log_count, log_total,
+                        brain.getPath())
+            continue
+
+        if getattr(obj, 'cached_result', None):
+            obj.setSparqlCacheResults(obj.cached_result)
+            del obj.cached_result
+            migrated += 1
+            transaction.commit()
+            if log_count % 100 == 0:
+                logger.info('INFO: Transaction committed to zodb (%s/%s)',
+                            log_count, log_total)
+
+    message = 'Migrated cached_result for %s Sparqls ...' % migrated
+    logger.info(message)
+    return message

--- a/eea/sparql/upgrades/evolve5200.py
+++ b/eea/sparql/upgrades/evolve5200.py
@@ -21,7 +21,6 @@ def migrate_sparql_cached_result(context):
     migrated = 0
     for brain in brains:
         log_count += 1
-        logger.info('PATH %s::%s: %s', log_count, log_total, brain.getPath())
         try:
             obj = brain.getObject()
         except Exception:
@@ -30,8 +29,16 @@ def migrate_sparql_cached_result(context):
             continue
 
         if getattr(obj, 'cached_result', None):
+            logger.info('PATH %s::%s: %s', log_count, log_total, brain.getPath())
             obj.setSparqlCacheResults(obj.cached_result)
-            del obj.cached_result
+            obj.cached_result.clear()
+            try:
+                del obj.cached_result
+            except AttributeError:
+                # we can't delete the dict however we are ok with at least
+                # emptying the results from it therefore we allow the
+                # transaction to be made
+                pass
             migrated += 1
             transaction.commit()
             if log_count % 100 == 0:


### PR DESCRIPTION
Right now when we make a version the cached sparq_results used by the export functionality is
stored with the object which can hurt performance of the history diff and bloats data.fs
This pull request moves the cached_results to a blob field but keeps the sparql_result as a normal
field in order to get diffing of the string concatenated results.
